### PR TITLE
Better support for Key-Value-formed config, caching variables from such configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,38 @@ you for this:
         $ figlet MyApp > priv/helo.txt
         ```
 
+
+5. Provides some helpers to deal with configuration:
+
+    * pass {only_kv, true} among other options to confetti:use/2 - this will
+    ensure that your config is formatted as follows:
+
+        ```
+        {foo_key, "FOO_Value"}.
+        {bar_key, [{"BAR", value}]}.
+        {{more, complex, key}, "and simple value"}.
+        ```
+
+    * use confetti:fetch_cache/1 instead of confetti:fetch/1
+    * enjoy fast and easy configuration variable fetching with confetti_cache:get/1
+    and confetti_cache:get_many/2:
+
+        ```
+        > confetti:fetch_cache(example).
+        [{foo,bar},
+         {baz,[{test,1},
+               {another_test,<<"FOOBARBAZ ALL GOOD GUYZ">>}]}]
+        > confetti_cache:get(foo).
+        bar
+        > confetti_cache:get_many([foo, baz, bar]).
+        [{foo,bar},
+         {baz,[{test,1},
+               {another_test,<<"FOOBARBAZ ALL GOOD GUYZ">>}]},
+         none]
+        > confetti_cache:get_many([foo, baz, bar], throw).
+        ** exception throw: {key_not_found, bar}
+        ```
+
 Try it out quickly
 ------------------
 
@@ -138,5 +170,3 @@ Feel encouraged to spot bugs/poor code and implement new sexy features.
 
 Also, make sure, you add yourself to the ``authors`` where appropriate!
 Thanks.
-
-

--- a/conf/example_kv.conf
+++ b/conf/example_kv.conf
@@ -1,0 +1,4 @@
+%% This is some comment
+{foo, bar}.
+{baz, [{test, 1},
+       {another_test, <<"FOOBARBAZ ALL GOOD GUYZ">>}]}.

--- a/src/confetti_cache.erl
+++ b/src/confetti_cache.erl
@@ -1,0 +1,76 @@
+%%%-------------------------------------------------------------------
+%%% @author Dmitry Groshev
+%%% @copyright (C) 2012, Selectel
+%%% @doc
+%%% Confetti cache module
+%%% @end
+%%%-------------------------------------------------------------------
+
+-module(confetti_cache).
+
+%% API
+-export([write/1, read/0, get/1, get_many/1, get_many/2]).
+
+-spec write([{any(), any()}]) -> ok.
+
+%% @doc
+%% Writes an entire configuration (which should be a proplist) to cache.
+
+write(Lst) when is_list(Lst) ->
+    case confetti_utils:ensure_proplist(Lst) of
+        true -> ok;
+        false -> throw("only proplist configs are cacheable")
+    end,
+    [erlang:put({confetti_cache, K}, V) || {K, V} <- Lst],
+    ok.
+
+-spec read() -> [{any(), any()}].
+
+%% @doc
+%% Reads an entire configureation from cache.
+
+read() ->
+    [{K, V} || {{confetti_cache, K}, V} <- erlang:get()].
+
+-spec get(any()) -> any() | none.
+
+%% @doc
+%% Reads configuration value from cache by key. If key wasn't found,
+%% returns none.
+
+get(K) ->
+    case erlang:get({confetti_cache, K}) of
+        undefined -> none;
+        X -> X
+    end.
+
+-spec get_many([any()] | [{any(), any()}]) -> [any()].
+
+%% @doc
+%% Reads a list of configuration values from cache by list of keys. If some
+%% keys weren't found, returns none instead of that keys.
+%% @see get_many/2
+
+get_many(Ks) ->
+    get_many(Ks, nothrow).
+
+-spec get_many([any()] | [{any(), any()}], throw|nothrow) -> [any()].
+
+%% @doc
+%% Reads a list of configuration values from cache by list of keys. Behaviour
+%% in the case of missing key depends on second argument - if it is equal to
+%% 'throw', throws key_not_found exception; if it is equal to 'nothrow',
+%% behaves similarly to get_many/1.
+
+get_many(Ks, ThrowOrNot) ->
+    [case erlang:get({confetti_cache, K}) of
+         undefined -> none_or_throw(K, ThrowOrNot);
+         X -> X
+     end || K <- Ks].
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+none_or_throw(K, throw) -> throw({key_not_found, K});
+none_or_throw(_, nothrow) -> none.

--- a/src/confetti_utils.erl
+++ b/src/confetti_utils.erl
@@ -7,7 +7,7 @@
 %%%-------------------------------------------------------------------
 -module(confetti_utils).
 -author('adam.rutkowski@jtendo.com').
--export([u_consult/1, fname/1, fname/2]).
+-export([u_consult/1, fname/1, fname/2, ensure_proplist/1]).
 -export([raise_alarm/2, clear_alarm/1]).
 -include("confetti.hrl").
 
@@ -38,6 +38,17 @@ u_consult(File) ->
         Error ->
             Error
     end.
+
+%% names speaks for itself
+ensure_proplist([]) -> true;
+ensure_proplist([Term|Terms]) ->
+    case Term of
+        {_K, _V} -> ensure_proplist(Terms);
+        _ -> false
+    end;
+ensure_proplist(_) -> false.
+
+
 
 %%%===================================================================
 %%% API (alarms)


### PR DESCRIPTION
I've added an option {only_kv, Boolean} to confetti:use/2 so it can control that config that was passed consists only from {Key, Value} pairs. Example:

```
{foo, "foo value"}.
{bar, "BAR value"}.
{test, [{test1, 1}, {test2, 2}]}.
```

I've also added confetti_cache module and confetti:fetch_cache/1 function, so configs like this can be cached in process dict and fetched from there by key.
